### PR TITLE
LPC improvements

### DIFF
--- a/activate.sh
+++ b/activate.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+source venv/bin/activate
+export PYTHONPATH=src

--- a/src/figures/__init__.py
+++ b/src/figures/__init__.py
@@ -18,3 +18,4 @@ def plot_all(args=None):
     CorrectionsPlot(e, args).offset()
     CorrectionsPlot(e, args).all()
     LPCPlot(e, args).common_lpc_autoc_averaging()
+    LPCPlot(e, args).common_lpc_variances()

--- a/src/figures/__init__.py
+++ b/src/figures/__init__.py
@@ -1,5 +1,6 @@
 import straw
 from .corrections import CorrectionsPlot
+from .experiments import Experiments
 from .lpc import LPCPlot
 
 
@@ -16,3 +17,4 @@ def plot_all(args=None):
     CorrectionsPlot(e, args).gain()
     CorrectionsPlot(e, args).offset()
     CorrectionsPlot(e, args).all()
+    LPCPlot(e, args).common_lpc_autoc_averaging()

--- a/src/figures/baseplot.py
+++ b/src/figures/baseplot.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+
+from matplotlib import pyplot as plt
+
+import straw
+
+
+class BasePlot:
+    def __init__(self, e: straw.Encoder, args=None):
+        self._args = args
+        self._e = e
+        self.fig_dir = Path(getattr(self._args, "fig_dir", "outputs"))
+        self.fig_dir.mkdir(parents=True, exist_ok=True)
+        self.fig_show = getattr(self._args, "fig_show", False)
+
+    def save(self, file_name: str):
+        plt.savefig(self.fig_dir / file_name)
+
+        if self.fig_show:
+            plt.show()

--- a/src/figures/baseplot.py
+++ b/src/figures/baseplot.py
@@ -13,8 +13,8 @@ class BasePlot:
         self.fig_dir.mkdir(parents=True, exist_ok=True)
         self.fig_show = getattr(self._args, "fig_show", False)
 
-    def save(self, file_name: str):
+    def save(self, file_name: str, force_show=False):
         plt.savefig(self.fig_dir / file_name)
 
-        if self.fig_show:
+        if self.fig_show or force_show:
             plt.show()

--- a/src/figures/corrections.py
+++ b/src/figures/corrections.py
@@ -1,21 +1,11 @@
-from pathlib import Path
-
-import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 import seaborn as sns
 
-import straw
+from figures.baseplot import BasePlot
 
 
-class CorrectionsPlot:
-    def __init__(self, e: straw.Encoder, args=None):
-        self._args = args
-        self._e = e
-        self.fig_dir = Path(getattr(self._args, "fig_dir", "outputs"))
-        self.fig_dir.mkdir(parents=True, exist_ok=True)
-        self.fig_show = getattr(self._args, "fig_show", False)
-
+class CorrectionsPlot(BasePlot):
     def shift(self):
         frame = self._e.sample_frame()
         f = frame["frame"][8:160]
@@ -33,10 +23,7 @@ class CorrectionsPlot:
         s.set_ylabels("Sample value (16-bit)")
         s.tight_layout()
 
-        plt.savefig(self.fig_dir / "shift.pdf")
-
-        if self.fig_show:
-            plt.show()
+        self.save("shift.pdf")
 
     def gain(self):
         frame = self._e.sample_frame()
@@ -55,10 +42,7 @@ class CorrectionsPlot:
         s.set_ylabels("Sample value (16-bit)")
         s.tight_layout()
 
-        plt.savefig(self.fig_dir / "gain.pdf")
-
-        if self.fig_show:
-            plt.show()
+        self.save("gain.pdf")
 
     def offset(self):
         frame = self._e.sample_frame()
@@ -77,10 +61,7 @@ class CorrectionsPlot:
         s.set_ylabels("Sample value (16-bit)")
         s.tight_layout()
 
-        plt.savefig(self.fig_dir / "offset.pdf")
-
-        if self.fig_show:
-            plt.show()
+        self.save("offset.pdf")
 
     def all(self):
         frame = self._e.sample_frame()
@@ -99,7 +80,4 @@ class CorrectionsPlot:
         s.set_ylabels("Sample value (16-bit)")
         s.tight_layout()
 
-        plt.savefig(self.fig_dir / "all.pdf")
-
-        if self.fig_show:
-            plt.show()
+        self.save("all.pdf")

--- a/src/figures/experiments.py
+++ b/src/figures/experiments.py
@@ -19,6 +19,9 @@ def func(df):
     mid = variances.mean()
     mid_idx = np.abs(variances - mid).idxmin()
 
+    # NOTE: for some reason subtracting the weakest channel does the smallest harm
+    # mid_idx = variances.idxmin()
+
     df["residual"] = df["residual"].apply(sub, x2=df["residual"][mid_idx])
     # df["residual"] = df["residual"].apply(np.subtract, x2=df["residual"][mid_idx])
 

--- a/src/figures/experiments.py
+++ b/src/figures/experiments.py
@@ -1,0 +1,13 @@
+from pathlib import Path
+
+import straw
+
+
+class Experiments:
+    # TODO: make base class
+    def __init__(self, e: straw.Encoder, args=None):
+        self._args = args
+        self._e = e
+        self.fig_dir = Path(getattr(self._args, "fig_dir", "outputs"))
+        self.fig_dir.mkdir(parents=True, exist_ok=True)
+        self.fig_show = getattr(self._args, "fig_show", False)

--- a/src/figures/experiments.py
+++ b/src/figures/experiments.py
@@ -1,5 +1,54 @@
+import numpy as np
+import pandas as pd
+import seaborn as sns
+from matplotlib import pyplot as plt
+
 from figures.baseplot import BasePlot
 
 
+def sub(x1, x2):
+    return x1 - x2
+
+
+def func(df):
+    """
+    Finds the medium channels residual and subtracts it from all other channels
+    :return: new residuals
+    """
+    variances = df["residual"].apply(np.var)
+    mid = variances.mean()
+    mid_idx = np.abs(variances - mid).idxmin()
+
+    df["residual"] = df["residual"].apply(sub, x2=df["residual"][mid_idx])
+    # df["residual"] = df["residual"].apply(np.subtract, x2=df["residual"][mid_idx])
+
+    new_variances = df["residual"].apply(np.var)
+
+    ov = sum(variances)
+    nv = sum(new_variances) + variances[mid_idx]
+    print(f"Old: {ov}\nNew: {nv}")
+    return df["residual"]
+
+
 class Experiments(BasePlot):
-    pass
+    def tmp(self):
+        data = self._e.sample_frame_multichannel()
+
+        new_residuals = func(data)
+        data["residual"] = new_residuals
+
+        df = {"x": [], "value": [], "Channel": []}
+        for i, ds in enumerate(data["residual"]):
+            df["x"] += [i for i in range(len(ds))]
+            df["Channel"] += [i for _ in ds]
+            df["value"] += list(ds)
+        df = pd.DataFrame(df)
+
+        s = sns.relplot(data=df, kind="line", x="x", y="value", hue="Channel", height=2.5, aspect=3)
+
+        plt.title("Frame residuals with common LPC coefficients (averaged autoc)")
+        s.set_xlabels("Sample")
+        s.set_ylabels("Sample value (16-bit)")
+        s.tight_layout()
+
+        self.save("tmp.png", True)

--- a/src/figures/experiments.py
+++ b/src/figures/experiments.py
@@ -42,6 +42,7 @@ class Experiments(BasePlot):
 
         df = {"x": [], "value": [], "Channel": []}
         for i, ds in enumerate(data["residual"]):
+            ds = ds[:60]
             df["x"] += [i for i in range(len(ds))]
             df["Channel"] += [i for _ in ds]
             df["value"] += list(ds)

--- a/src/figures/experiments.py
+++ b/src/figures/experiments.py
@@ -1,13 +1,5 @@
-from pathlib import Path
-
-import straw
+from figures.baseplot import BasePlot
 
 
-class Experiments:
-    # TODO: make base class
-    def __init__(self, e: straw.Encoder, args=None):
-        self._args = args
-        self._e = e
-        self.fig_dir = Path(getattr(self._args, "fig_dir", "outputs"))
-        self.fig_dir.mkdir(parents=True, exist_ok=True)
-        self.fig_show = getattr(self._args, "fig_show", False)
+class Experiments(BasePlot):
+    pass

--- a/src/figures/lpc.py
+++ b/src/figures/lpc.py
@@ -1,5 +1,4 @@
 import sys
-from pathlib import Path
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -7,18 +6,11 @@ import pandas as pd
 import seaborn as sns
 
 # NOTE: Do not import this without checking for args -> seaborn and mpl should be optional dependencies
-import straw
+from figures.baseplot import BasePlot
 from straw.lpc import steps
 
 
-class LPCPlot:
-    def __init__(self, e: straw.Encoder, args=None):
-        self._args = args
-        self._e = e
-        self.fig_dir = Path(getattr(self._args, "fig_dir", "outputs"))
-        self.fig_dir.mkdir(parents=True, exist_ok=True)
-        self.fig_show = getattr(self._args, "fig_show", False)
-
+class LPCPlot(BasePlot):
     def print_lpc_and_qlp(self):
         """
         Prints LPC and QLP coefficients
@@ -62,10 +54,7 @@ class LPCPlot:
         s.set_ylabels("Sample value (16-bit)")
         s.tight_layout()
 
-        plt.savefig(self.fig_dir / "prediction_comparison.pdf")
-
-        if self.fig_show:
-            plt.show()
+        self.save("prediction_comparison.pdf")
 
     def residual(self):
         """
@@ -89,10 +78,7 @@ class LPCPlot:
         s.set_ylabels("Sample value (16-bit)")
         s.tight_layout()
 
-        plt.savefig(self.fig_dir / "residual.pdf")
-
-        if self.fig_show:
-            plt.show()
+        self.save("residual.pdf")
 
     def common_lpc_autoc_averaging(self):
         """
@@ -113,7 +99,4 @@ class LPCPlot:
         s.set_ylabels("Sample value (16-bit)")
         s.tight_layout()
 
-        plt.savefig(self.fig_dir / "lpc_averaged.png")
-
-        if self.fig_show:
-            plt.show()
+        self.save("lpc_averaged.png")

--- a/src/figures/lpc.py
+++ b/src/figures/lpc.py
@@ -94,9 +94,39 @@ class LPCPlot(BasePlot):
 
         s = sns.relplot(data=df, kind="line", x="x", y="value", hue="Channel", height=2.5, aspect=3)
 
-        plt.title("Residuals with common LPC coefficients (averaged autoc)")
+        plt.title("Frame residuals with common LPC coefficients (averaged autoc)")
         s.set_xlabels("Sample")
         s.set_ylabels("Sample value (16-bit)")
         s.tight_layout()
 
         self.save("lpc_averaged.png")
+
+        # Also print variances...
+
+        print("Variances:")
+        table = pd.DataFrame({
+            "channel": data["channel"],
+            "variance": data["residual"].apply(np.var),
+        })
+        table = table.set_index("channel")
+
+        print(table.T.to_latex(caption="Variances",
+                               position="H", float_format="{:0.3f}".format, escape=False))
+        # print("\n".join([f"{f:.3f}" for f in data["residual"].apply(np.var)]))
+
+    def common_lpc_variances(self):
+        """
+        Show variances across all frames across for all channels
+        """
+        df = self._e.get_data()
+        df["variance"] = df["residual"].apply(np.var)
+
+        s = sns.relplot(data=df, kind="line", x="seq", y="variance", hue="channel", height=6, aspect=1.8)
+        s.set(ylim=(0, 7500))
+
+        plt.title("Residual variance with common LPC coefficients (averaged autoc)")
+        s.set_xlabels("Frame")
+        s.set_ylabels("Variance")
+        s.tight_layout()
+
+        self.save("lpc_averaged_variances.png")

--- a/src/figures/lpc.py
+++ b/src/figures/lpc.py
@@ -20,6 +20,9 @@ class LPCPlot:
         self.fig_show = getattr(self._args, "fig_show", False)
 
     def print_lpc_and_qlp(self):
+        """
+        Prints LPC and QLP coefficients
+        """
         frame = self._e.sample_frame()
         lpc = steps.compute_lpc(frame["frame"], 8)
         qlp, shift = steps.quantize_lpc(lpc, 12)
@@ -38,6 +41,9 @@ class LPCPlot:
         print("%%%%%%%% INSERT TABLE %%%%%%%%")
 
     def prediction_comparison(self):
+        """
+        Shows the original frame and a predicted frame
+        """
         frame = self._e.sample_frame()
         # FIXME: magic number order=8
         f = frame["frame"][8:160]
@@ -62,6 +68,10 @@ class LPCPlot:
             plt.show()
 
     def residual(self):
+        """
+        Shows a residual frame
+        :return:
+        """
         frame = self._e.sample_frame()
         # FIXME: magic number order=8
         f = frame["frame"][8:160]
@@ -80,6 +90,30 @@ class LPCPlot:
         s.tight_layout()
 
         plt.savefig(self.fig_dir / "residual.pdf")
+
+        if self.fig_show:
+            plt.show()
+
+    def common_lpc_autoc_averaging(self):
+        """
+        Shows the residuals after using common LPC coefficients across all channels
+        """
+        data = self._e.sample_frame_multichannel()
+        df = {"x": [], "value": [], "Channel": []}
+        for i, ds in enumerate(data["residual"]):
+            df["x"] += [i for i in range(len(ds))]
+            df["Channel"] += [i for _ in ds]
+            df["value"] += list(ds)
+        df = pd.DataFrame(df)
+
+        s = sns.relplot(data=df, kind="line", x="x", y="value", hue="Channel", height=2.5, aspect=3)
+
+        plt.title("Residuals with common LPC coefficients (averaged autoc)")
+        s.set_xlabels("Sample")
+        s.set_ylabels("Sample value (16-bit)")
+        s.tight_layout()
+
+        plt.savefig(self.fig_dir / "lpc_averaged.png")
 
         if self.fig_show:
             plt.show()

--- a/src/straw/encoder.py
+++ b/src/straw/encoder.py
@@ -97,7 +97,8 @@ class Encoder:
                                          result_type="reduce")
 
     def save_file(self, filename):
-        self._data["stream"] = self._encoder.frames_to_bitstreams(self._data["residual"])
+        self._data["bps"] = np.full(len(self._data["residual"]), 4, dtype="B")
+        self._data["stream"] = self._encoder.frames_to_bitstreams(self._data["residual"], self._data["bps"])
         self._data["stream_len"] = self._data["stream"].apply(len)
         # TODO: actually save bitstreams
 

--- a/src/straw/encoder.py
+++ b/src/straw/encoder.py
@@ -104,7 +104,8 @@ class Encoder:
 
     def restore(self):
         self._data["residual_len"] = self._data["residual"].apply(len)
-        self._data["residual"] = self._encoder.bitstreams_to_frames(self._data["stream"], self._data["residual_len"])
+        self._data["residual"] = self._encoder.bitstreams_to_frames(
+            self._data["stream"], self._data["residual_len"], self._data["bps"])
 
         p = ParallelCompute()
         self._data["restored"] = p.apply(self._data, lpc.compute_original, axis=1, result_type="reduce")

--- a/src/straw/encoder.py
+++ b/src/straw/encoder.py
@@ -117,11 +117,14 @@ class Encoder:
         # FIXME: this is misleading
         print(f"Size of the resulting dataframe: {self.usage_mib():.3f} MiB", file=stream)
 
-    def sample_frame(self):
+    def sample_frame(self) -> pd.Series:
         return self._data.loc[0]
 
-    def sample_frame_multichannel(self):
+    def sample_frame_multichannel(self) -> pd.DataFrame:
         return self._data[self._data["seq"] == 0]
+
+    def get_data(self) -> pd.DataFrame:
+        return self._data
 
     def _clean(self):
         self._raw = None

--- a/src/straw/encoder.py
+++ b/src/straw/encoder.py
@@ -120,6 +120,9 @@ class Encoder:
     def sample_frame(self):
         return self._data.loc[0]
 
+    def sample_frame_multichannel(self):
+        return self._data[self._data["seq"] == 0]
+
     def _clean(self):
         self._raw = None
         self._data = None

--- a/src/straw/encoder.py
+++ b/src/straw/encoder.py
@@ -13,7 +13,7 @@ from .rice import Ricer
 class Encoder:
     # Values which should be parametrized
     # TODO: find the best values for these
-    _lpc_order = 8
+    _lpc_order = 10
     _lpc_precision = 12  # bits
     _frame_size = 4096  # bytes
 

--- a/src/straw/lpc/ext.pyx
+++ b/src/straw/lpc/ext.pyx
@@ -2,6 +2,36 @@
 # cython: language_level=3
 import numpy as np
 
+####################
+# LPC coefficients #
+####################
+
+# @cython.cdivision(True)
+# def compute_lp_coefficients(long[:] autoc, int order, double[:] lpc):
+#     cdef int j
+#     cdef double r, err
+#     cdef double tmp
+#
+#     err = autoc[0]
+#
+#     r = -autoc[order + 1]
+#     for j in range(order):
+#         r -= lpc[j] * autoc[order - j]
+#     r /= err
+#
+#     lpc[order] = r
+#     for j in range(order >> 1):
+#         tmp = lpc[j]
+#         lpc[j] += r * lpc[order - 1 - j]
+#         lpc[order - 1 - j] += r * tmp
+#
+#     if order & 1:
+#         lpc[j] += lpc[j] * r
+#
+#     err *= (1.0 - r * r)
+#     return err
+
+
 ################
 # Quantization #
 ################

--- a/src/straw/lpc/steps.py
+++ b/src/straw/lpc/steps.py
@@ -159,7 +159,7 @@ def quantize_lpc_cython(lpc_c, precision) -> (np.array, int):
 ##############
 
 
-def predict_signal(frame: np.array, qlp: np.array, shift: int):
+def predict_signal(frame: np.array, qlp: np.array, shift):
     """
     Executes LPC prediction
     The resulting predicted signal starts with the order-th sample
@@ -168,6 +168,7 @@ def predict_signal(frame: np.array, qlp: np.array, shift: int):
     :param shift: coefficient quantization shift
     :return: predicted frame with shape [order:]
     """
+    shift = int(shift)
     if qlp is None or len(qlp) == 0:
         return None
 

--- a/src/straw/lpc/steps.py
+++ b/src/straw/lpc/steps.py
@@ -2,6 +2,7 @@ import math
 import sys
 
 import numpy as np
+import pandas as pd
 import pyximport
 from scipy.linalg import solve_toeplitz
 
@@ -28,13 +29,22 @@ def compute_lpc(signal: np.array, p: int) -> np.array:
     :return: array of length p containing LPC coefficients
     """
 
-    # Extend to 64 bits to prevent overflows
-    signal = signal.astype("i8")
+    if isinstance(signal, pd.Series):
+        # we are dealing with a multichannel LPC
+        # Extend to 64 bits to prevent overflows
+        if not signal.apply(np.any).all():
+            return None
 
-    if not signal.any():
-        return None
+        r = np.asarray([_autocorr(s.astype("i8"), p + 1) for s in signal])
+        r = np.mean(r, axis=0)
+    else:
+        # Extend to 64 bits to prevent overflows
+        signal = signal.astype("i8")
 
-    r = _autocorr(signal, p + 1)
+        if not signal.any():
+            return None
+
+        r = _autocorr(signal, p + 1)
 
     return solve_toeplitz(r[:-1], r[1:], check_finite=False)
 
@@ -162,6 +172,18 @@ def predict_signal(frame: np.array, qlp: np.array, shift: int):
         return None
 
     return np.convolve(frame, qlp, mode="full")[len(qlp) - 1:-len(qlp)] >> shift
+
+
+def predict_compute_residusal(frame: np.array, qlp: np.array, shift: int):
+    """
+    Executes LPC prediction and returns the residual by subtracting the original frame from the predicted signal
+    :param frame: signal frame
+    :param qlp: quantized LPC coefficients
+    :param shift: coefficient quantization shift
+    :return: frame residual with shape [order:]
+    """
+    predicted = predict_signal(frame, qlp, shift)
+    return (frame[len(qlp):] - predicted).astype(np.int16)
 
 
 ###############

--- a/src/straw/lpc/wrappers.py
+++ b/src/straw/lpc/wrappers.py
@@ -29,10 +29,17 @@ def compute_residual(data: pd.DataFrame):
     :param data: input dataframe slice with columns [frame, qlp, shift]
     :return: the input dataframe slice with a [residual] column added
     """
-    qlp = data["qlp"][data["qlp"].first_valid_index()]
-    shift = int(data["shift"][data["shift"].first_valid_index()])
+    qlp_idx = data[["qlp"]].first_valid_index()
+    shift_idx = data[["shift"]].first_valid_index()
 
-    data["residual"] = data["frame"].apply(steps.predict_compute_residusal, qlp=qlp, shift=shift)
+    if qlp_idx is None or shift_idx is None:
+        data["residual"] = None
+    elif isinstance(data["frame"], np.ndarray):
+        data["residual"] = steps.predict_compute_residusal(data["frame"], data["qlp"], data["shift"])
+    else:
+        data["residual"] = data["frame"].apply(steps.predict_compute_residusal,
+                                               qlp=data["qlp"][qlp_idx],
+                                               shift=int(data["shift"][shift_idx]))
 
     return data
 

--- a/src/straw/lpc/wrappers.py
+++ b/src/straw/lpc/wrappers.py
@@ -40,7 +40,7 @@ def compute_residual(data: pd.DataFrame) -> np.array:
 def compute_original(data: pd.DataFrame) -> np.array:
     """
     Computes the original from the given residual signal with quantized LPC coefficients and warmup samples
-    :param data: input dataframe with columns [residual, frame[:order], qlp, shift]
+    :param data: input dataframe with columns [frame, qlp, shift]
     :return: residual as a numpy array
     """
     return steps.restore_signal_cython(data["residual"], data["qlp"], data["shift"], data["frame"][:len(data["qlp"])])

--- a/src/straw/rice/ext.pyx
+++ b/src/straw/rice/ext.pyx
@@ -51,18 +51,18 @@ def _append_n_bits(bits: bitarray, short number, short n):
     bits.extend([number >> (n - i - 1) & 1 for i in range(n)])
 
 @cython.cdivision(True)
-def encode_frame(bits: bitarray, short[:] frame, short m, short k):
+def encode_frame(bits: bitarray, short[:] frame, short k):
     """
     Encodes a whole residual frame and appends it to the end of the given bitstream
     :param bits: bitaray to which the bits will be appended
     :param frame: the frame to be encoded
-    :param m: rice m constant
     :param k: rice k constant
     :return: None
     """
-    cdef short q, s
+    cdef short m, q, s
     cdef Py_ssize_t x_max, i
     x_max = frame.shape[0]
+    m = 1 << k
 
     for i in range(x_max):
         s = _interleave(frame[i])
@@ -84,19 +84,19 @@ cdef char _get_bit(bits: bitarray, Py_ssize_t *bit_i):
     bit_i[0] += 1
     return bits[bit_i[0] - 1]
 
-def decode_frame(short[:] frame, bits: bitarray, short m, short k):
+def decode_frame(short[:] frame, bits: bitarray, short k):
     """
     Decodes a whole residual frame from the given bitstream
     :param frame: numpy array where the decoded frame should be stored
     :param bits: bitaray from which the frame should be restored
-    :param m: rice m constant
     :param k: rice k constant
     :return: None
     """
-    cdef short q, s, j
+    cdef short m, q, s, j
     cdef Py_ssize_t x_max, i
     cdef Py_ssize_t bit_i = 0
     x_max = frame.shape[0]
+    m = 1 << k
 
     for i in range(x_max):
         q = 0

--- a/src/straw/rice/ext.pyx
+++ b/src/straw/rice/ext.pyx
@@ -64,6 +64,8 @@ def encode_frame(bits: bitarray, short[:] frame, short k):
     x_max = frame.shape[0]
     m = 1 << k
 
+    # cdef short last = 0
+
     for i in range(x_max):
         s = _interleave(frame[i])
 
@@ -75,6 +77,23 @@ def encode_frame(bits: bitarray, short[:] frame, short k):
         bits.append(0)
 
         _append_n_bits(bits, s, k)
+
+        # Length of bitstream: 48877826 bits, bytes: 6109729 aligned (5.83 MiB)
+        # Length of bitstream: 48877826 bits, bytes: 6109729 aligned (5.83 MiB)
+
+        # TODO: feed-forward rice implementation
+        # for some reason gives exactly the same results as constant param
+        # Update rice param
+        # if last == 8:
+        #     last = 0
+        #     k += 1
+        #     m = 1 << k
+        #     continue
+        #
+        # if s >= m:
+        #     last = (last << 1) | 1
+        # else:
+        #     last = 0
 
 ############
 # Decoding #

--- a/src/straw/rice/ricer.py
+++ b/src/straw/rice/ricer.py
@@ -15,40 +15,47 @@ class Ricer:
     Currently only supports memory for for memory efficiency comparisons and benchmarks
     """
 
-    def __init__(self, m):
-        self.m = m
-        self.k = int(np.log2(self.m))
+    def __init__(self, k):
+        self.k = k
+        self.m = 1 << k
         self.parallel = ParallelCompute()
 
     ############
     # Encoding #
     ############
 
-    def frame_to_bitstream(self, frame: np.array) -> bitarray:
+    def frame_to_bitstream(self, frame: np.array, bps: int) -> bitarray:
         """
         Encode a numpy frame to a bitsream
         :param frame: numpy array of samples to encode
+        :param bps: expected bits per sample
         :return: encoded bitarray
         """
         data = bitarray()
 
         if frame is not None:
-            ext.encode_frame(data, frame, self.m, self.k)
+            ext.encode_frame(data, frame, 1 << bps, bps)
 
         return data
 
-    def frames_to_bitstreams(self, frames: pd.Series, parallel: bool = True) -> pd.Series:
+    def _frame_to_bitstream_df_expander(self, df: pd.DataFrame) -> np.array:
+        return self.frame_to_bitstream(df["frame"], df["bps"])
+
+    def frames_to_bitstreams(self, frames: pd.Series, bps: pd.Series, parallel: bool = True) -> pd.Series:
         """
         Encode a series of frames to a series of bitsreams
         :param frames: series of frames
+        :param bps: expected bits per second for this frame
         :param parallel: if True then use multithreading
         :return: encoded bitarrays
         """
 
-        if not parallel:
-            return frames.apply(self.frame_to_bitstream)
+        comp = pd.DataFrame({"frame": frames, "bps": bps})
 
-        return self.parallel.apply(frames, self.frame_to_bitstream)
+        if not parallel:
+            return comp.apply(self._frame_to_bitstream_df_expander, axis=1, result_type="reduce")
+
+        return self.parallel.apply(comp, self._frame_to_bitstream_df_expander, axis=1, result_type="reduce")
 
     ############
     # Decoding #

--- a/src/straw/rice/ricer.py
+++ b/src/straw/rice/ricer.py
@@ -20,6 +20,33 @@ class Ricer:
         self.m = 1 << k
         self.parallel = ParallelCompute()
 
+    ##########################
+    # Optimal order guessing #
+    ##########################
+
+    @staticmethod
+    def _compute_expected_bits_per_sample(lpc_error, residual_samples):
+        error_scale = 0.5 / residual_samples
+
+        if lpc_error > 0.0:
+            bps = 0.5 * np.log(error_scale * lpc_error) / np.log(2)
+            if bps >= 0.0:
+                return bps
+            else:
+                return 0.0
+        elif lpc_error < 0.0:
+            return 1e32
+        else:
+            return 0.0
+
+    @staticmethod
+    def guess_parameter(lpc_error, residual_samples):
+        # TODO: this gives a shitty output
+        lpc_residual_bits_per_sample = Ricer._compute_expected_bits_per_sample(lpc_error, residual_samples)
+        rice_parameter = int(lpc_residual_bits_per_sample + 0.5) if (lpc_residual_bits_per_sample > 0.0) else 0
+        rice_parameter += 1  # account for signed conversion
+        return rice_parameter
+
     ############
     # Encoding #
     ############

--- a/test/test_lpc_integrity.py
+++ b/test/test_lpc_integrity.py
@@ -20,8 +20,8 @@ class LPCSignalIntegrity(unittest.TestCase):
         df["qlp"] = [qlp]
         df["shift"] = [shift]
 
-        residual = lpc.compute_residual(df.loc[0])
-        restored = lpc.steps.restore_signal(residual, qlp, shift, self.signal[:self.lpc_order])
+        df = lpc.compute_residual(df.loc[0])
+        restored = lpc.steps.restore_signal(df["residual"], qlp, shift, self.signal[:self.lpc_order])
 
         self.assertEqual((self.signal - restored).any(), False)
 
@@ -36,8 +36,8 @@ class LPCSignalIntegrity(unittest.TestCase):
         df["qlp"] = [None]
         df["shift"] = [0]
 
-        residual = lpc.compute_residual(df.loc[0])
-        self.assertIsNone(residual)
+        df = lpc.compute_residual(df.loc[0])
+        self.assertIsNone(df["residual"])
 
 
 if __name__ == '__main__':

--- a/test/test_rice.py
+++ b/test/test_rice.py
@@ -10,7 +10,8 @@ class Rice(unittest.TestCase):
     """
     Rice parameter 4
     """
-    m = 4
+    k = 2
+    m = 1 << k
     r = rice.Ricer(m)
 
     def test_rice_ext_arange(self):
@@ -24,7 +25,7 @@ class Rice(unittest.TestCase):
         for i in frame:
             r_o += resources.rice_str(i, self.m)
 
-        bits = self.r.frame_to_bitstream(frame)
+        bits = self.r.frame_to_bitstream(frame, self.k)
 
         self.assertEqual(bits.to01(), r_o)
 
@@ -35,23 +36,23 @@ class Rice(unittest.TestCase):
         for i in frame:
             r_o += resources.rice_str(i, self.m)
 
-        bits = self.r.frame_to_bitstream(frame)
+        bits = self.r.frame_to_bitstream(frame, self.k)
 
         self.assertEqual(bits.to01(), r_o)
 
     def test_rice_ext_arange_decode(self):
         frame = np.arange(20, dtype=np.int16)
 
-        bits = self.r.frame_to_bitstream(frame)
-        decoded = self.r.bitstream_to_frame(bits, len(frame))
+        bits = self.r.frame_to_bitstream(frame, self.k)
+        decoded = self.r.bitstream_to_frame(bits, len(frame), self.k)
 
         self.assertListEqual(frame.tolist(), decoded.tolist())
 
     def test_rice_ext_signal_decode(self):
         frame = resources.get_signal()[0]
 
-        bits = self.r.frame_to_bitstream(frame)
-        decoded = self.r.bitstream_to_frame(bits, len(frame))
+        bits = self.r.frame_to_bitstream(frame, self.k)
+        decoded = self.r.bitstream_to_frame(bits, len(frame), self.k)
 
         self.assertListEqual(frame.tolist(), decoded.tolist())
 


### PR DESCRIPTION
+ Change default order to 10
+ Add common LPC coefficients trough averaging autocorrelation coefficients -> doesn't impact the resulting file size much
```
Separate: Length of bitstream: 48877826 bits, bytes: 6109729 aligned (5.83 MiB)
Averaged: Length of bitstream: 48952282 bits, bytes: 6119036 aligned (5.84 MiB)
```
+ Separate rice parameter for each frame - make a reference implementation for feed forward rice encoding which didn't result in much improvement YET, see #21
+ Add more plots